### PR TITLE
Fix crash when saving plans on empty slots

### DIFF
--- a/planing/io.c
+++ b/planing/io.c
@@ -183,7 +183,10 @@ ubyte plOpen(U32 objId, ubyte mode, FILE ** fh)
 		    sprintf(name2, "%s%d%s", name1, i + 1,
 			    PLANING_PLAN_EXTENSION);
 
-		    dskBuildPathName(DISK_CHECK_FILE, DATADISK, name2, pllPath2);
+		    if(!dskBuildPathName(DISK_CHECK_FILE, DATADISK, name2, pllPath2)) {
+		        /* allow for uninitialized (non-existent) save files. */
+		        dskBuildPathName(DISK_CHECK_DIR, DATADISK, name2, pllPath2);
+		    }
 
 		    *fh = dskOpen(pllPath2, Planing_Open[mode]);
 


### PR DESCRIPTION
On Linux, the game crashed when trying to save plans in slots where the save file did not yet exist, when the datadisk directory is not written in all lowercase.

This has been fixed. In case the save file cannot be found, only perform a case-insensitive lookup of the directory component beforehand.

This seems to be the only case in the code where this happens. The handling of the global save files seems to use an entirely different mechanism.

Without this patch, the issue also has a working workaround: The game will print an error message, giving you the path that could not be resolved, e.g. `./datadisk/TobaEta1.pln`. Now assuming  your datadisk directory is actually called `DATADISK`, you can just go ahead and create all files: ` touch ./DATADISK/TOBAETA{1-4}.PLN`. Saving should then work without crashing the game.